### PR TITLE
Add tokenize input output

### DIFF
--- a/tests/test_sft_trainer.py
+++ b/tests/test_sft_trainer.py
@@ -489,8 +489,6 @@ class SFTTrainerTester(unittest.TestCase):
     def test_sft_trainer_with_model_input_output_dataset(self):
         # NOTE: These cases should be merged into the test above once this PR is stable.
         # If the dataset doesn't have input/output keys, it should raise a KeyError
-        # TODO: should the input/output fields by a param? Doing so would probably be
-        # more in line with the dataset_text_field arg...
         with tempfile.TemporaryDirectory() as tmp_dir:
             training_args = TrainingArguments(
                 output_dir=tmp_dir,
@@ -526,20 +524,6 @@ class SFTTrainerTester(unittest.TestCase):
             trainer.train()
             assert trainer.state.log_history[(-1)]["train_loss"] is not None
             assert "model.safetensors" in os.listdir(tmp_dir + "/checkpoint-1")
-
-            # but this should only work if we are using the seq2seq collator
-            collator = DataCollatorForCompletionOnlyLM("### Response:\n", tokenizer=self.tokenizer, mlm=False)
-            with pytest.raises(ValueError):
-                _ = SFTTrainer(
-                    model=self.model,
-                    args=training_args,
-                    train_dataset=dataset_with_input_output,
-                    dataset_text_field=None,
-                    formatting_func=None,
-                    max_seq_length=16,
-                    packing=False,
-                    data_collator=collator,
-                )
 
     def test_sft_trainer_with_multiple_eval_datasets(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -662,9 +646,6 @@ class SFTTrainerTester(unittest.TestCase):
         non_masked_tokens2 = input_ids[1][labels[1] != -100]
         result_text2 = tokenizer.decode(non_masked_tokens2)
         assert result_text2 == " I should not be masked. I should not be masked too."
-
-    def test_sft_trainer_with_no_packing_or_formatting_or_dataset_text_field():
-        pass
 
     def test_sft_trainer_infinite_with_model(self):
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -170,10 +170,8 @@ class SFTTrainer(Trainer):
                 "You passed a `DataCollatorForCompletionOnlyLM` to the SFTTrainer. This is not compatible with the `packing` argument."
             )
 
-        if not packing and formatting_func is None and dataset_text_field is None and data_collator is not None and not isinstance(data_collator, DataCollatorForSeq2Seq):
-            raise ValueError(
-                "If no formatting_func / dataset_text_field provided, the data_collator should be a `DataCollatorForSeq2Seq` object"
-            )
+        # TODO: Add proper validation for collator compatability when not padding
+        # with no format func and no dataset text field
 
         if is_peft_available() and peft_config is not None:
             if not isinstance(peft_config, PeftConfig):

--- a/trl/trainer/sft_trainer.py
+++ b/trl/trainer/sft_trainer.py
@@ -28,6 +28,7 @@ from transformers import (
     AutoTokenizer,
     DataCollator,
     DataCollatorForLanguageModeling,
+    DataCollatorForSeq2Seq,
     PreTrainedModel,
     PreTrainedTokenizerBase,
     Trainer,
@@ -169,6 +170,11 @@ class SFTTrainer(Trainer):
                 "You passed a `DataCollatorForCompletionOnlyLM` to the SFTTrainer. This is not compatible with the `packing` argument."
             )
 
+        if not packing and formatting_func is None and dataset_text_field is None and data_collator is not None and not isinstance(data_collator, DataCollatorForSeq2Seq):
+            raise ValueError(
+                "If no formatting_func / dataset_text_field provided, the data_collator should be a `DataCollatorForSeq2Seq` object"
+            )
+
         if is_peft_available() and peft_config is not None:
             if not isinstance(peft_config, PeftConfig):
                 raise ValueError(
@@ -245,14 +251,14 @@ class SFTTrainer(Trainer):
             # if not stays #None
             formatting_func = get_formatting_func_from_dataset(train_dataset, tokenizer)
 
+        requires_input_output_keys = False
         if not packing:
-            # if dataset_text_field is None and formatting_func is None:
-            #     raise ValueError(
-            #         "You passed `packing=False` to the SFTTrainer, but you didn't pass a `dataset_text_field` or `formatting_func` argument."
-            #     )
-
+            requires_input_output_keys = (dataset_text_field is None and formatting_func is None)
             if data_collator is None:
-                data_collator = DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=False)
+                # Fall back to the appropriate collator type based on the input_output_keys
+                data_collator = (DataCollatorForSeq2Seq(tokenizer=tokenizer, padding=True)
+                if requires_input_output_keys
+                else DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=False))
 
         # Pre-process the datasets only once per node. The remaining processes will use the cache.
         with PartialState().local_main_process_first():
@@ -269,6 +275,7 @@ class SFTTrainer(Trainer):
                     num_of_sequences,
                     chars_per_token,
                     remove_unused_columns=args.remove_unused_columns if args is not None else True,
+                    requires_input_output_keys=requires_input_output_keys,
                     **dataset_kwargs,
                 )
             if eval_dataset is not None:
@@ -365,6 +372,7 @@ class SFTTrainer(Trainer):
         num_of_sequences,
         chars_per_token,
         remove_unused_columns=True,
+        requires_input_output_keys=False,
         append_concat_token=True,
         add_special_tokens=True,
     ):
@@ -384,6 +392,7 @@ class SFTTrainer(Trainer):
                 formatting_func,
                 add_special_tokens,
                 remove_unused_columns,
+                requires_input_output_keys,
             )
 
         else:
@@ -408,6 +417,7 @@ class SFTTrainer(Trainer):
         formatting_func=None,
         add_special_tokens=True,
         remove_unused_columns=True,
+        requires_input_output_keys=False,
     ):
         use_formatting_func = formatting_func is not None and dataset_text_field is None
         self._dataset_sanity_checked = False
@@ -421,7 +431,7 @@ class SFTTrainer(Trainer):
             tokenizer.eos_token=None
 
             new_source = []
-            for (input_element, output_element)  in zip(element['input'], element['output']): 
+            for (input_element, output_element) in zip(element['input'], element['output']):
                 if not input_element.endswith((' ', '\n', '\t')) and not output_element.startswith((' ', '\n', '\t')):
                     new_source.append(input_element + ' ' + output_element + eos_token)
                 else:
@@ -474,9 +484,16 @@ class SFTTrainer(Trainer):
                 "You passed `remove_unused_columns=False` on a non-packed dataset. This might create some issues with the default collator and yield to errors. If you want to "
                 f"inspect dataset other columns (in this case {extra_columns}), you can subclass `DataCollatorForLanguageModeling` in case you used the default collator and create your own data collator in order to inspect the unused dataset columns."
             )
-
-        if 'input' in dataset.column_names and 'output' in dataset.column_names:
-            tokenize_func= tokenize_input_output
+        
+        if requires_input_output_keys:
+            if "input" in dataset.column_names and "output" in dataset.column_names:
+                # TODO: if we execute this input path, it is expected that we are using a seq2seq
+                # collator. If that is the case, the tokenizer should had a pad_token; this is set
+                # to eos automatically if it's unset and no tokenizer is provided, but we should
+                # properly handle if a tokenizer with no padding token is given.
+                tokenize_func = tokenize_input_output
+            else:
+                raise KeyError("Missing input / output keys")
         else:
             tokenize_func = tokenize
 


### PR DESCRIPTION
Some small fixes + tests to start to validate that things are working properly. Namely:
- if packing is false and no formatting func / dataset text field is given, the collator that is created should be a seq2seq collator
- fixes error handling around a few cases, e.g.,
    - wrong collator type is given for the case above
    - the above case is given, but the dataset doesn't have `input` / `output` fields; with the current code, this is needed or else the tokenize func fails. Might be a good idea to make these keys configurable
- Tests to ensure that the sft trainer init behaviors are as expected, and that if things are good, we can train on the tiny model without exploding